### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Using <a href="https://github.com/ajeetdsouza/starship">starship</a> in xxh. Sta
 
 ## Install
 ```shell
-xxh +I xxh-plugin-prerun-starship
+xxh +I xxh-plugin-prerun-starship+git+https://github.com/izissise/xxh-plugin-prerun-starship.git
 ```
 
 ## Usage


### PR DESCRIPTION
Could not get the plugin installed with the proposed command (it defaults to the xxh github group). So the explicit installation type and github url should be provided.